### PR TITLE
Fixed the Map support to work when key's have values that aren't strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,19 @@ MongoDB.Bson.Serialization.FSharp.register()
 `Seq<_>` is serialized as an array. Order is preserved.
 
 ## Map
-`Map<_, _>` is serialized as an object. Do not rely on the order of the keys.
+`Map<_, _>` is serialized as an array of documents using `DictionaryRepresentation.ArrayOfDocuments`.
+Each entry is stored as `{ "k": <key>, "v": <value> }`.
+
+This representation correctly round-trips maps with any key type, including numeric types such as `uint`, `int`, etc.
+
+Example — `Map<uint, string>` with one entry:
+```json
+[{ "k": 1, "v": "Trivial" }]
+```
+
+> **Note:** Previous versions serialized maps as BSON objects (field names as strings), which caused
+> deserialization to silently return an empty map for non-`string` key types. Existing documents
+> stored in the old format must be migrated before upgrading.
 
 ## Option
 `Option<_>` is either serialized as:

--- a/src/FSharp.MongoDB.Bson/Serialization/Serializers/FSharpMapSerializer.fs
+++ b/src/FSharp.MongoDB.Bson/Serialization/Serializers/FSharpMapSerializer.fs
@@ -24,7 +24,10 @@ open MongoDB.Bson.Serialization.Serializers
 type FSharpMapSerializer<'KeyType, 'ValueType when 'KeyType : comparison and 'KeyType: not null>() =
     inherit SerializerBase<Map<'KeyType, 'ValueType>>()
 
-    let serializer = DictionaryInterfaceImplementerSerializer<Dictionary<'KeyType, 'ValueType>>()
+    let serializer =
+        DictionaryInterfaceImplementerSerializer<Dictionary<'KeyType, 'ValueType>>(
+            MongoDB.Bson.Serialization.Options.DictionaryRepresentation.ArrayOfDocuments
+        )
 
     override _.Serialize (context, args, mapValue) =
         let dictValue = Dictionary()


### PR DESCRIPTION
Fix FSharpMapSerializer silently losing data for non-string key types

Map<'K, 'V> was serialized using DictionaryRepresentation.Document (the default), which stores map entries as BSON field names. On deserialization, the C# driver's DictionaryInterfaceImplementerSerializer could not parse string field names back into non-string key types (e.g. uint, int), causing the map to silently deserialize as empty.

This fix switches the representation to DictionaryRepresentation.ArrayOfDocuments, which stores each entry as { "k": <key>, "v": <value> }. BSON values are typed, so any key type that the C# driver can serialize individually will also round-trip correctly through a map.

Breaking change: Documents stored in the old field-name format will not deserialize correctly with this change. Existing data must be migrated.