### PR TITLE
Publish test results in workflows

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -13,6 +13,7 @@ on:
 permissions:
   contents: read
   checks: write
+  pull-requests: write
 
 jobs:
   build-and-test:
@@ -53,10 +54,12 @@ jobs:
           if-no-files-found: warn
 
       - name: Publish test report
-        if: always()
+        if: (!cancelled())
         continue-on-error: true
-        uses: dorny/test-reporter@v2
+        uses: EnricoMi/publish-unit-test-result-action@v2
         with:
-          name: Test Results (PR)
-          path: TestResults/**/*.trx
-          reporter: dotnet-trx
+          files: TestResults/**/*.trx
+          check_name: Test Results (PR)
+          comment_title: Test Results (PR)
+          comment_mode: always
+          job_summary: true

--- a/.github/workflows/on-push-branch.yml
+++ b/.github/workflows/on-push-branch.yml
@@ -52,10 +52,11 @@ jobs:
           if-no-files-found: warn
 
       - name: Publish test report
-        if: always()
+        if: (!cancelled())
         continue-on-error: true
-        uses: dorny/test-reporter@v2
+        uses: EnricoMi/publish-unit-test-result-action@v2
         with:
-          name: Test Results (Branches)
-          path: TestResults/**/*.trx
-          reporter: dotnet-trx
+          files: TestResults/**/*.trx
+          check_name: Test Results (Branches)
+          comment_mode: off
+          job_summary: true

--- a/.github/workflows/on-push-tag.yml
+++ b/.github/workflows/on-push-tag.yml
@@ -37,6 +37,24 @@ jobs:
       - name: Build, test, and pack
         run: make publish-all config=Release version=${{ env.BUILD_VERSION }}
 
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results-tag
+          path: TestResults/**/*.trx
+          if-no-files-found: warn
+
+      - name: Publish test report
+        if: (!cancelled())
+        continue-on-error: true
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        with:
+          files: TestResults/**/*.trx
+          check_name: Test Results (Tag)
+          comment_mode: off
+          job_summary: true
+
       - name: Extract release notes from changelog
         shell: bash
         run: ./.github/scripts/extract-release-notes.sh "${GITHUB_REF_NAME}" > "${RUNNER_TEMP}/release-notes.md"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to FSharp.MongoDB are documented in this file.
 
 ## [Unreleased]
 
+- Added GitHub test result publishing across PR, branch, and tag workflows, including Actions job summaries and PR comments.
 - Updated the repository and GitHub Actions workflows to use the .NET SDK `10.0.301` baseline.
 - Restored the isomorphic serialization test coverage to guard C# and F# BSON parity again.
 


### PR DESCRIPTION
## Summary
- publish .NET TRX test results in PR, branch, and tag workflows
- add GitHub Actions job summaries for test runs
- publish PR test results as PR comments
- update the changelog

## Validation
- `make verify-changelog`