### PR TITLE
Support BsonDictionaryOptions on F# maps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to FSharp.MongoDB are documented in this file.
 
 ## [Unreleased]
 
+- Fixed F# map support for `BsonDictionaryOptions`, including `ArrayOfDocuments` coverage.
+
 ## [0.5.0-beta]
 
 

--- a/src/FSharp.MongoDB.Bson/Serialization/Serializers/FSharpMapSerializer.fs
+++ b/src/FSharp.MongoDB.Bson/Serialization/Serializers/FSharpMapSerializer.fs
@@ -16,15 +16,19 @@
 namespace MongoDB.Bson.Serialization.Serializers
 
 open System.Collections.Generic
+open MongoDB.Bson.Serialization
+open MongoDB.Bson.Serialization.Options
 open MongoDB.Bson.Serialization.Serializers
 
 /// <summary>
 /// Serializer for F# maps.
 /// </summary>
-type FSharpMapSerializer<'KeyType, 'ValueType when 'KeyType : comparison and 'KeyType: not null>() =
+type FSharpMapSerializer<'KeyType, 'ValueType when 'KeyType : comparison and 'KeyType: not null>
+    (
+        serializer:
+            DictionaryInterfaceImplementerSerializer<Dictionary<'KeyType, 'ValueType>, 'KeyType, 'ValueType>
+    ) =
     inherit SerializerBase<Map<'KeyType, 'ValueType>>()
-
-    let serializer = DictionaryInterfaceImplementerSerializer<Dictionary<'KeyType, 'ValueType>>()
 
     override _.Serialize (context, args, mapValue) =
         let dictValue = Dictionary()
@@ -36,3 +40,23 @@ type FSharpMapSerializer<'KeyType, 'ValueType when 'KeyType : comparison and 'Ke
         serializer.Deserialize(context, args)
         |> Seq.map (|KeyValue|)
         |> Map.ofSeq
+
+    interface IBsonDictionarySerializer with
+        member _.DictionaryRepresentation = serializer.DictionaryRepresentation
+        member _.KeySerializer = serializer.KeySerializer :> IBsonSerializer
+        member _.ValueSerializer = serializer.ValueSerializer :> IBsonSerializer
+
+    interface IDictionaryRepresentationConfigurable with
+        member _.DictionaryRepresentation = serializer.DictionaryRepresentation
+        member _.WithDictionaryRepresentation dictionaryRepresentation =
+            FSharpMapSerializer<'KeyType, 'ValueType>(serializer.WithDictionaryRepresentation(dictionaryRepresentation))
+            :> IBsonSerializer
+
+    interface IDictionaryRepresentationConfigurable<FSharpMapSerializer<'KeyType, 'ValueType>> with
+        member _.WithDictionaryRepresentation dictionaryRepresentation =
+            FSharpMapSerializer<'KeyType, 'ValueType>(serializer.WithDictionaryRepresentation(dictionaryRepresentation))
+
+    new () =
+        FSharpMapSerializer<'KeyType, 'ValueType>(
+            DictionaryInterfaceImplementerSerializer<Dictionary<'KeyType, 'ValueType>, 'KeyType, 'ValueType>()
+        )

--- a/tests/CSharpDataModels/DataModels.cs
+++ b/tests/CSharpDataModels/DataModels.cs
@@ -1,5 +1,7 @@
 ﻿namespace CSharpDataModels;
 using MongoDB.Bson;
+using MongoDB.Bson.Serialization.Attributes;
+using MongoDB.Bson.Serialization.Options;
 
 public record Pair
 {
@@ -39,4 +41,12 @@ public record RecordDataModel
     public Pair? RecordOpt { get; init; }
 
     public required Dictionary<string, int> Map { get; init; }
+}
+
+public record UserId([property: BsonGuidRepresentation(GuidRepresentation.Standard)] Guid Value);
+
+public record UserMapDocument
+{
+    [BsonDictionaryOptions(DictionaryRepresentation.ArrayOfDocuments)]
+    public required Dictionary<UserId, string> Users { get; init; }
 }

--- a/tests/FSharp.MongoDB.Bson.Tests/FSharp.MongoDB.Bson.Tests.fsproj
+++ b/tests/FSharp.MongoDB.Bson.Tests/FSharp.MongoDB.Bson.Tests.fsproj
@@ -11,6 +11,7 @@
     <Compile Include="SerializationTestHelpers.fs" />
     <Compile Include="Serialization\FSharpListSerializationTests.fs" />
     <Compile Include="Serialization\FSharpMapSerializationTests.fs" />
+    <Compile Include="Serialization\FSharpMapDictionaryRepresentationTests.fs" />
     <Compile Include="Serialization\FSharpOptionSerializationTests.fs" />
     <Compile Include="Serialization\FSharpNRTSerializationTests.fs" />
     <Compile Include="Serialization\FSharpValueOptionSerializationTests.fs" />

--- a/tests/FSharp.MongoDB.Bson.Tests/Serialization/FSharpMapDictionaryRepresentationTests.fs
+++ b/tests/FSharp.MongoDB.Bson.Tests/Serialization/FSharpMapDictionaryRepresentationTests.fs
@@ -1,0 +1,88 @@
+namespace FSharp.MongoDB.Bson.Tests.Serialization
+
+open System
+open CSharpDataModels
+open FsUnit
+open MongoDB.Bson
+open MongoDB.Bson.Serialization.Attributes
+open MongoDB.Bson.Serialization.Options
+open NUnit.Framework
+
+module FSharpMapDictionaryRepresentation =
+
+    [<CLIMutable>]
+    type FsUserId =
+        { [<BsonGuidRepresentation(GuidRepresentation.Standard)>]
+          Value: Guid }
+
+    [<CLIMutable>]
+    type FsUserMapDocument =
+        { [<BsonDictionaryOptions(DictionaryRepresentation.ArrayOfDocuments)>]
+          Users: Map<FsUserId, string> }
+
+    let private userGuid = Guid.Parse("550e8400-e29b-41d4-a716-446655440000")
+
+    let private expectedDocument =
+        BsonDocument(
+            [ BsonElement(
+                  "Users",
+                  BsonArray(
+                      [ BsonDocument(
+                            [ BsonElement("k", BsonDocument("Value", BsonBinaryData(userGuid, GuidRepresentation.Standard)))
+                              BsonElement("v", BsonString("John")) ]) ])) ])
+
+    [<Test>]
+    let ``serialize map with complex key as array of documents`` () =
+        let value =
+            { Users =
+                Map [ { Value = userGuid }, "John" ] }
+
+        let result = serialize value
+        result |> should equal expectedDocument
+
+    [<Test>]
+    let ``deserialize map with complex key from array of documents`` () =
+        let result = deserialize<FsUserMapDocument> expectedDocument
+
+        result.Users
+        |> should equal (Map [ { Value = userGuid }, "John" ])
+
+    [<Test>]
+    let ``CSharp and FSharp models serialize the same array of documents representation`` () =
+        let csUsers =
+            System.Collections.Generic.Dictionary<CSharpDataModels.UserId, string>(
+                dict [ (CSharpDataModels.UserId(userGuid), "John") ])
+
+        let csValue =
+            new CSharpDataModels.UserMapDocument(Users = csUsers)
+
+        let fsValue =
+            { Users =
+                Map [ { Value = userGuid }, "John" ] }
+
+        let csDoc = serialize csValue
+        let fsDoc = serialize fsValue
+
+        csDoc |> should equal expectedDocument
+        fsDoc |> should equal expectedDocument
+
+    [<Test>]
+    let ``cross deserialize map with complex key using array of documents`` () =
+        let csUsers =
+            System.Collections.Generic.Dictionary<CSharpDataModels.UserId, string>(
+                dict [ (CSharpDataModels.UserId(userGuid), "John") ])
+
+        let csDoc =
+            serialize (new CSharpDataModels.UserMapDocument(Users = csUsers))
+
+        let fsValue = deserialize<FsUserMapDocument> csDoc
+        fsValue.Users |> should equal (Map [ { Value = userGuid }, "John" ])
+
+        let fsDoc =
+            serialize
+                { Users =
+                    Map [ { Value = userGuid }, "John" ] }
+
+        let csValue = deserialize<CSharpDataModels.UserMapDocument> fsDoc
+        csValue.Users.Count |> should equal 1
+        csValue.Users[CSharpDataModels.UserId(userGuid)] |> should equal "John"


### PR DESCRIPTION
## Summary
- make `FSharpMapSerializer` implement the dictionary configurability interfaces expected by `BsonDictionaryOptions`
- add array-of-documents serialization and deserialization coverage for complex map keys across F# and C# models
- update the changelog for the new F# map dictionary representation support
- cover https://github.com/fsprojects/FSharp.MongoDB/issues/32

## Testing
- DOTNET_ROLL_FORWARD=Major dotnet test tests/FSharp.MongoDB.Bson.Tests/FSharp.MongoDB.Bson.Tests.fsproj --no-restore