### PR TITLE
chore: move test harness to .NET 10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to FSharp.MongoDB are documented in this file.
 
 ## [Unreleased]
 
+- Updated the test harness projects to target .NET 10 so local and CI test execution stays aligned with the repository SDK baseline.
+
 ## [0.5.0-beta]
 
 

--- a/tests/CSharpDataModels/CSharpDataModels.csproj
+++ b/tests/CSharpDataModels/CSharpDataModels.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net9.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>

--- a/tests/FSharp.MongoDB.Bson.Tests/FSharp.MongoDB.Bson.Tests.fsproj
+++ b/tests/FSharp.MongoDB.Bson.Tests/FSharp.MongoDB.Bson.Tests.fsproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <VSTestLogger>trx</VSTestLogger>


### PR DESCRIPTION
## Summary
- retarget the C# test data model project to `net10.0`
- retarget the F# test project to `net10.0`
- document the test harness alignment in the unreleased changelog

## Verification
- `dotnet build FSharp.MongoDB.sln --configuration Release --no-restore`
- `dotnet test FSharp.MongoDB.sln --configuration Release --logger "trx" --results-directory TestResults`